### PR TITLE
Update extension.js

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,7 +28,6 @@ class fsExtension extends EventEmitter
 
 		//start the outpus channel to show progress/status
 		this._outChan = vscode.window.createOutputChannel("FileSync Output");
-		this._outChan.show(true);
 
 		//add command for creating default config file.
 		vscode.commands.registerCommand("filesync.createConfigFile", this._onCreateConfigFile.bind(this));


### PR DESCRIPTION
Don't show the "FileSync Output" log section by default. It's too annoying that the log is opened in the editor always, even for projects that don't use the file sync. The user should manually open the log if they want to troubleshoot any sync issues.